### PR TITLE
Refactor Crossover Operator

### DIFF
--- a/bindings/pygenalg/operators/crossover.pyx
+++ b/bindings/pygenalg/operators/crossover.pyx
@@ -10,8 +10,11 @@ from .crossovercpp cimport SinglePointCrossover as cppSinglePointCrossover
 cdef class MultiPointCrossover:
     cdef cppMultiPointCrossover[vector[bool]]* _objcpp
 
-    def __cinit__(self, n_crossovers: int) -> None:
-        self._objcpp = new cppMultiPointCrossover[vector[bool]](n_crossovers)
+    def __cinit__(self, n_crossovers: int, gene_size: int=1) -> None:
+        self._objcpp = new cppMultiPointCrossover[vector[bool]](
+            n_crossovers,
+            gene_size
+        )
 
     def __dealloc__(self) -> None:
         del self._objcpp
@@ -19,8 +22,8 @@ cdef class MultiPointCrossover:
 cdef class SinglePointCrossover:
     cdef cppSinglePointCrossover[vector[bool]]* _objcpp
 
-    def __cinit__(self) -> None:
-        self._objcpp = new cppSinglePointCrossover[vector[bool]]()
+    def __cinit__(self, gene_size: int=1) -> None:
+        self._objcpp = new cppSinglePointCrossover[vector[bool]](gene_size)
 
     def __dealloc__(self) -> None:
         del self._objcpp

--- a/bindings/pygenalg/operators/crossovercpp.pxd
+++ b/bindings/pygenalg/operators/crossovercpp.pxd
@@ -7,8 +7,11 @@ cdef extern from "operators/crossover.hpp" namespace "genalg::operators":
 
     cdef cppclass MultiPointCrossover[G]:
         MultiPointCrossover(
-            size_t n_crossovers
+            size_t n_crossovers,
+            size_t gene_size
         ) except +
 
     cdef cppclass SinglePointCrossover[G]:
-        SinglePointCrossover() except +
+        SinglePointCrossover(
+            size_t gene_size
+        ) except +

--- a/src/genalg/operators/crossover.hpp
+++ b/src/genalg/operators/crossover.hpp
@@ -32,10 +32,11 @@ namespace genalg {
         class MultiPointCrossover : public CrossoverOperator<G> {
         private:
             const std::size_t n_crossovers_;
+            const std::size_t gene_size_;
 
         public:
-            explicit MultiPointCrossover(std::size_t n)
-                : n_crossovers_{n} {}
+            explicit MultiPointCrossover(std::size_t n_crossovers, std::size_t gene_size=1)
+                : n_crossovers_{n_crossovers}, gene_size_{gene_size} {}
 
             std::array<G, 2> cross(const G& g1, const G& g2,
                                    std::default_random_engine& rng) const override;
@@ -50,8 +51,8 @@ namespace genalg {
         template<typename G>
         class SinglePointCrossover : public MultiPointCrossover<G> {
         public:
-            SinglePointCrossover()
-                : MultiPointCrossover<G>(1) {}
+            explicit SinglePointCrossover(std::size_t gene_size=1)
+                : MultiPointCrossover<G>(1, gene_size) {}
 
             /// Cross two individuals using single point crossover technique.
             ///
@@ -78,14 +79,17 @@ namespace genalg {
         template<typename G>
         std::array<G, 2> MultiPointCrossover<G>::cross(const G &g1, const G &g2,
                                                        std::default_random_engine& rng) const {
+            assert(g1.size() % this->gene_size_ == 0);
             assert(g1.size() == g2.size());
             assert(this->n_crossovers_ <= g1.size());
 
             G genome1 = g1;
             G genome2 = g2;
 
-            std::vector<std::size_t> indexes(g1.size());
-            std::iota(indexes.begin(), indexes.end(), 1);
+            std::vector<std::size_t> indexes(g1.size() / this->gene_size_);
+            for(int i = 0; i < indexes.size(); ++i) {
+                indexes[i] = i * this->gene_size_;
+            }
 
             std::vector<std::size_t> crossovers;
             std::sample(indexes.begin(), indexes.end(),


### PR DESCRIPTION
The crossover operator should consider the number of indices that represents a single gene in the genome to avoid increased mutation.